### PR TITLE
Serialize outputs in a structured and documented form

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ and spaces must match perfectly in order for the answers to match properly.
 | `String`                   | `"example"`                |
 | `INTEGER`                  | `12`                       |
 | `DOUBLE`                   | `5.405`                    |
-| `CHARACTER`                | `'A'`                      |
+| `CHARACTER`                | `"A"`                      |
 | `BOOLEAN`                  | `true`                     |
-| `ARRAY_STRING`             | `["a", "b"]`               |
-| `ARRAY_INTEGER`            | `[-10, 20]`                |
-| `ARRAY_DOUBLE`             | `[0.0, 5.75, -1.12]`       |
-| `ARRAY_CHARACTER`          | `['a', 'b']`               |
-| `ARRAY_BOOLEAN`            | `[true, false]`            |
+| `ARRAY_STRING`             | `["ab", "cd"]`             |
+| `ARRAY_INTEGER`            | `[-10,20]`                 |
+| `ARRAY_DOUBLE`             | `[0.0,5.75,-1.12]`         |
+| `ARRAY_CHARACTER`          | `["a", "b"]`               |
+| `ARRAY_BOOLEAN`            | `[true,false]`             |
 

--- a/README.md
+++ b/README.md
@@ -157,14 +157,14 @@ a problem, as well as an example JSON serialization.
 
 | Syntax                     | Example Serialization      |
 | -------------------------- | -------------------------- |
-| `String`                   | `"example"`                |
+| `String`                   | `example`                  |
 | `INTEGER`                  | `12`                       |
 | `DOUBLE`                   | `5.405`                    |
-| `CHARACTER`                | `"A"`                      |
+| `CHARACTER`                | `A`                        |
 | `BOOLEAN`                  | `true`                     |
-| `ARRAY_STRING`             | `["ab", "cd"]`             |
+| `ARRAY_STRING`             | `[ab, cd]`                 |
 | `ARRAY_INTEGER`            | `[-10, 20]`                |
 | `ARRAY_DOUBLE`             | `[0.0, 5.75, -1.12]`       |
-| `ARRAY_CHARACTER`          | `["a", "b"]`               |
+| `ARRAY_CHARACTER`          | `[a, b]`                   |
 | `ARRAY_BOOLEAN`            | `[true, false]`            |
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ and spaces must match perfectly in order for the answers to match properly.
 | `DOUBLE`                   | `5.405`                    |
 | `CHARACTER`                | `"A"`                      |
 | `BOOLEAN`                  | `true`                     |
-| `ARRAY_STRING`             | `["ab", "cd"]`             |
+| `ARRAY_STRING`             | `["ab","cd"]`             |
 | `ARRAY_INTEGER`            | `[-10,20]`                 |
 | `ARRAY_DOUBLE`             | `[0.0,5.75,-1.12]`         |
 | `ARRAY_CHARACTER`          | `["a", "b"]`               |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The problem provides several key pieces of information for judging:
 * Names and types of method parameters (e.g. 1 param: "array", of type `ARRAY_INTEGER`)
 * Return type of method (e.g. `STRING`)
 * Test case inputs (format described below)
-* Test case outputs (TBD whether provided manually or through a solution file) 
+* Test case outputs (correct answers to each input)  
 
 The boilerplate code for each problem is dynamically generated in Rocket Den's 
 [main](https://github.com/rocketden/main) repository, with the method typically
@@ -76,11 +76,14 @@ public class Driver {
         ...
         
         try {
-            captureConsole();
+            System.out.println(DELIMITER_TEST_CASE);
             int output_1 = new Solution().findMax(test_1_param_1);
+
+            System.out.println(DELIMITER_SUCCESS);
             captureOutput(output_1);
         } catch (Exception e) {
-            captureError(e);
+            System.out.println(DELIMITER_FAILURE);
+            e.printStackTrace();
         }
 
         ...
@@ -88,17 +91,33 @@ public class Driver {
 }
 ```
 
-Above, `captureConsole`, `captureOutput`, and `captureError` are additional 
-generated methods that capture all 3 output types of the user's program, which
-will be evaluated and returned later on (TBD: how output will be saved).
+Above, `captureOutput`, and `captureError` is an additionally generated method 
+that serializes and prints the user return object to the console. The resulting
+output from the user program is then parsed, judged, and sent back to the user. 
+
+## Output Format
+
+The output of each driver program is used to judge the results of the user's
+program. The output follows a template similar to the following: 
+
+```
+TODO: template goes here
+
+``` 
+
+When serialized into strings, the returned objects are directly compared to the 
+given outputs for the problem. Therefore, both the serialization process and the
+user-provided outputs should follow a specific JSON-type format in order to 
+ensure proper judging. 
 
 
-## Supported Types 
+### Output Serialization Formats 
 
 The following are the supported types for method parameters and return type for 
-a problem: 
+a problem, as well as the desired serialization format: 
 
 * `STRING`
+  * TODO - give format 
 * `INTEGER`
 * `DOUBLE`
 * `CHARACTER`

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ residing in a `Solution` class or similar (depending on the language of choice).
 Users are then responsible for implementing the method according to the problem
 description to pass the test cases.  
 
-### Input Format
+### Test Case Format
 
-The test case inputs are created in a partial JSON format. If a problem has N
-method parameters, then a corresponding test case will be N lines long, with
-the ith line containing the JSON input for the ith method parameter. 
+The test case inputs and outputs are represented in a JSON format. If a problem has
+multiple method parameters, then a corresponding test case input will be N lines long, 
+with the ith line containing the JSON input for the ith method parameter. 
 
 e.g. A problem with method parameters `String[] values` and `Integer num` could 
 have the following test case input (note how each individual line is JSON-parsable): 
@@ -50,6 +50,13 @@ have the following test case input (note how each individual line is JSON-parsab
 ```
 [hello, world]
 5
+```
+
+e.g. A problem with expected output of type `Boolean[]` could have the following test
+case output:
+
+```
+[true, true, false]
 ```
 
 ## Driver Program
@@ -70,6 +77,11 @@ solved in Java, the driver program might be generated to look like the following
 
 ```java
 public class Driver {
+
+    public String serialize(int obj) {
+        return String.valueOf(obj);
+    }
+
     public static void main(String[] args) {
         int[] test_1_param_1 = {1, 2, 3};
         int[] test_2_param_1 = {1, 2, 3};
@@ -80,7 +92,7 @@ public class Driver {
             int output_1 = new Solution().findMax(test_1_param_1);
 
             System.out.println(DELIMITER_SUCCESS);
-            captureOutput(output_1);
+            System.out.println(serialize(output_1));
         } catch (Exception e) {
             System.out.println(DELIMITER_FAILURE);
             e.printStackTrace();
@@ -91,9 +103,8 @@ public class Driver {
 }
 ```
 
-Above, `captureOutput`, and `captureError` is an additionally generated method 
-that serializes and prints the user return object to the console. The resulting
-output from the user program is then parsed, judged, and sent back to the user. 
+The resulting output from the user program is then parsed, judged, and 
+sent back to the user. 
 
 ## Output Format
 
@@ -130,16 +141,19 @@ code was not able to return an answer). The lines afterwards are either the seri
 return output or the error message.  
 
 
-### Output Serialization Formats 
+### Output Serialization
 
-When serialized into strings, the returned objects are directly compared to the 
-given outputs for the problem. Therefore, both the serialization process and the
-user-provided outputs should follow a specific JSON-type format in order to 
-ensure proper judging. 
+The user's returned output is serialized in the same JSON format as used to represent
+the test case inputs and outputs. When judging a user's program, these serialized
+strings are read back into the tester service as Java objects and then directly
+compared to prevent small formatting differences in strings from causing misleading
+errors. 
+
+
+## Supported Types
 
 The following are the supported types for method parameters and return type for 
-a problem, as well as the desired serialization format. Note that brackets, quotes,
-and spaces must match perfectly in order for the answers to match properly. 
+a problem, as well as an example JSON serialization. 
 
 | Syntax                     | Example Serialization      |
 | -------------------------- | -------------------------- |
@@ -148,9 +162,9 @@ and spaces must match perfectly in order for the answers to match properly.
 | `DOUBLE`                   | `5.405`                    |
 | `CHARACTER`                | `"A"`                      |
 | `BOOLEAN`                  | `true`                     |
-| `ARRAY_STRING`             | `["ab","cd"]`             |
-| `ARRAY_INTEGER`            | `[-10,20]`                 |
-| `ARRAY_DOUBLE`             | `[0.0,5.75,-1.12]`         |
+| `ARRAY_STRING`             | `["ab", "cd"]`             |
+| `ARRAY_INTEGER`            | `[-10, 20]`                |
+| `ARRAY_DOUBLE`             | `[0.0, 5.75, -1.12]`       |
 | `ARRAY_CHARACTER`          | `["a", "b"]`               |
-| `ARRAY_BOOLEAN`            | `[true,false]`             |
+| `ARRAY_BOOLEAN`            | `[true, false]`            |
 

--- a/README.md
+++ b/README.md
@@ -101,30 +101,56 @@ The output of each driver program is used to judge the results of the user's
 program. The output follows a template similar to the following: 
 
 ```
-TODO: template goes here
+###########_TEST_CASE_############
+test 1 2 3 (user console output)
+here
+###########_SUCCESS_############
+3
+###########_TEST_CASE_############
+test 4 8 12
+here
+###########_SUCCESS_############
+12
+###########_TEST_CASE_############
+test -2 0 5
+###########_FAILURE_############
+java.lang.ArithmeticException: / by zero
+
+at Solution.runSuccess(Solution.java:25)
+
+...
 
 ``` 
+
+The delimiters are used to determine where one test case ends and another begins.
+For each test case, the first few lines are whatever the user prints to the console
+in their program. This is followed by either a success delimiter (the program runs
+without any exceptions) or a failure delimiter (an error occurred and thus the user's
+code was not able to return an answer). The lines afterwards are either the serialized
+return output or the error message.  
+
+
+### Output Serialization Formats 
 
 When serialized into strings, the returned objects are directly compared to the 
 given outputs for the problem. Therefore, both the serialization process and the
 user-provided outputs should follow a specific JSON-type format in order to 
 ensure proper judging. 
 
-
-### Output Serialization Formats 
-
 The following are the supported types for method parameters and return type for 
-a problem, as well as the desired serialization format: 
+a problem, as well as the desired serialization format. Note that brackets, quotes,
+and spaces must match perfectly in order for the answers to match properly. 
 
-* `STRING`
-  * TODO - give format 
-* `INTEGER`
-* `DOUBLE`
-* `CHARACTER`
-* `BOOLEAN`
-* `ARRAY_STRING`
-* `ARRAY_INTEGER`
-* `ARRAY_DOUBLE`
-* `ARRAY_CHARACTER`
-* `ARRAY_BOOLEAN`
+| Syntax                     | Example Serialization      |
+| -------------------------- | -------------------------- |
+| `String`                   | `"example"`                |
+| `INTEGER`                  | `12`                       |
+| `DOUBLE`                   | `5.405`                    |
+| `CHARACTER`                | `'A'`                      |
+| `BOOLEAN`                  | `true`                     |
+| `ARRAY_STRING`             | `["a", "b"]`               |
+| `ARRAY_INTEGER`            | `[-10, 20]`                |
+| `ARRAY_DOUBLE`             | `[0.0, 5.75, -1.12]`       |
+| `ARRAY_CHARACTER`          | `['a', 'b']`               |
+| `ARRAY_BOOLEAN`            | `[true, false]`            |
 

--- a/src/main/java/com/rocketden/tester/service/generators/DriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/DriverGeneratorService.java
@@ -21,7 +21,7 @@ public interface DriverGeneratorService {
 
     void writeEndingBoilerplate(FileWriter writer) throws IOException;
 
-    void writeToStringCode();
+    void writeToStringCode(FileWriter writer) throws IOException;
 
     // The implementation of the type's instantiation.
     String typeInstantiationToString(ProblemIOType ioType);

--- a/src/main/java/com/rocketden/tester/service/generators/DriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/DriverGeneratorService.java
@@ -13,7 +13,7 @@ public interface DriverGeneratorService {
 
     void writeDriverFile(String fileDirectory, Problem problem);
 
-    void writeStartingBoilerplate(FileWriter writer) throws IOException;
+    void writeStartingBoilerplate(FileWriter writer, Problem problem) throws IOException;
 
     void writeTestCases(FileWriter writer, Problem problem) throws IOException;
 
@@ -21,7 +21,7 @@ public interface DriverGeneratorService {
 
     void writeEndingBoilerplate(FileWriter writer) throws IOException;
 
-    void writeToStringCode(FileWriter writer) throws IOException;
+    String getToStringCode(ProblemIOType outputType) throws IOException;
 
     // The implementation of the type's instantiation.
     String typeInstantiationToString(ProblemIOType ioType);

--- a/src/main/java/com/rocketden/tester/service/generators/JavaDriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/JavaDriverGeneratorService.java
@@ -45,6 +45,8 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
     @Override
     public void writeStartingBoilerplate(FileWriter writer, Problem problem) throws IOException {
         writer.write(String.join("\n",
+            "import java.util.*;",
+            "",
             "public class Driver {",
             "",
             getToStringCode(problem.getOutputType()),
@@ -151,8 +153,17 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
 
     @Override
     public String getToStringCode(ProblemIOType outputType) {
-        // TODO Auto-generated method stub
-        return "";
+        String toStringCode;
+        if (outputType.getClassType().isArray()) {
+            toStringCode = "Arrays.toString(obj)";
+        } else {
+            toStringCode = "String.valueOf(obj)";
+        }
+
+        return String.join("\n",
+                String.format("\tpublic String serialize(%s obj) {", typeInstantiationToString(outputType)),
+                String.format("\t\treturn %s;", toStringCode),
+                "\t}");
     }
 
     @Override

--- a/src/main/java/com/rocketden/tester/service/generators/JavaDriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/JavaDriverGeneratorService.java
@@ -99,8 +99,8 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
 
         // Execute each of the test cases within separate try-catch blocks.
         for (int testNum = 1; testNum <= problem.getTestCases().size(); testNum++) {
-            // Print line to predict any console output.
-            writer.write(String.format("\t\tSystem.out.println(\"Console (%d):\");%n", testNum));
+            // Denote beginning of a new test case
+            writer.write(String.format("\t\tSystem.out.println(\"%s\");%n", DELIMITER_TEST_CASE));
 
             // Use try-catch block to print any errors.
             writer.write("\t\ttry {\n");
@@ -127,10 +127,10 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
 
             // Print solution output, catch errors that arise from method call.
             writer.write(String.join("\n",
-                String.format("\t\t\tSystem.out.println(\"Solution (%d):\");", testNum),
+                String.format("\t\t\tSystem.out.println(\"%s\");", DELIMITER_SUCCESS),
                 String.format("\t\t\tSystem.out.println(solution%d);", testNum),
                 "\t\t} catch (Exception e) {",
-                String.format("\t\t\tSystem.out.println(\"Error (%d):\");", testNum),
+                    String.format("\t\t\tSystem.out.println(\"%s\");", DELIMITER_FAILURE),
                 "\t\t\te.printStackTrace();",
                 "\t\t}\n"
             ));

--- a/src/main/java/com/rocketden/tester/service/generators/JavaDriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/JavaDriverGeneratorService.java
@@ -14,6 +14,7 @@ import com.rocketden.tester.model.problem.ProblemInput;
 import com.rocketden.tester.model.problem.ProblemTestCase;
 
 import com.rocketden.tester.service.parsers.InputParser;
+import com.rocketden.tester.service.parsers.OutputParser;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -100,7 +101,7 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
         // Execute each of the test cases within separate try-catch blocks.
         for (int testNum = 1; testNum <= problem.getTestCases().size(); testNum++) {
             // Denote beginning of a new test case
-            writer.write(String.format("\t\tSystem.out.println(\"%s\");%n", DELIMITER_TEST_CASE));
+            writer.write(String.format("\t\tSystem.out.println(\"%s\");%n", OutputParser.DELIMITER_TEST_CASE));
 
             // Use try-catch block to print any errors.
             writer.write("\t\ttry {\n");
@@ -127,10 +128,10 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
 
             // Print solution output, catch errors that arise from method call.
             writer.write(String.join("\n",
-                String.format("\t\t\tSystem.out.println(\"%s\");", DELIMITER_SUCCESS),
+                String.format("\t\t\tSystem.out.println(\"%s\");", OutputParser.DELIMITER_SUCCESS),
                 String.format("\t\t\tSystem.out.println(solution%d);", testNum),
                 "\t\t} catch (Exception e) {",
-                    String.format("\t\t\tSystem.out.println(\"%s\");", DELIMITER_FAILURE),
+                    String.format("\t\t\tSystem.out.println(\"%s\");", OutputParser.DELIMITER_FAILURE),
                 "\t\t\te.printStackTrace();",
                 "\t\t}\n"
             ));
@@ -146,7 +147,7 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
     }
 
     @Override
-    public void writeToStringCode() {
+    public void writeToStringCode(FileWriter writer) {
         // TODO Auto-generated method stub
 
     }

--- a/src/main/java/com/rocketden/tester/service/generators/JavaDriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/JavaDriverGeneratorService.java
@@ -33,7 +33,7 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
     public void writeDriverFile(String fileDirectory, Problem problem) {
         // Open writer using try-with-resources.
         try (FileWriter writer = new FileWriter(fileDirectory)) {
-            writeStartingBoilerplate(writer);
+            writeStartingBoilerplate(writer, problem);
             writeTestCases(writer, problem);
             writeExecuteTestCases(writer, problem);
             writeEndingBoilerplate(writer);
@@ -43,9 +43,12 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
     }
 
     @Override
-    public void writeStartingBoilerplate(FileWriter writer) throws IOException {
+    public void writeStartingBoilerplate(FileWriter writer, Problem problem) throws IOException {
         writer.write(String.join("\n",
             "public class Driver {",
+            "",
+            getToStringCode(problem.getOutputType()),
+            "",
             "\tpublic static void main (String[] args) {\n"
         ));
     }
@@ -129,7 +132,7 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
             // Print solution output, catch errors that arise from method call.
             writer.write(String.join("\n",
                 String.format("\t\t\tSystem.out.println(\"%s\");", OutputParser.DELIMITER_SUCCESS),
-                String.format("\t\t\tSystem.out.println(solution%d);", testNum),
+                String.format("\t\t\tSystem.out.println(serialize(solution%d));", testNum),
                 "\t\t} catch (Exception e) {",
                     String.format("\t\t\tSystem.out.println(\"%s\");", OutputParser.DELIMITER_FAILURE),
                 "\t\t\te.printStackTrace();",
@@ -147,9 +150,9 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
     }
 
     @Override
-    public void writeToStringCode(FileWriter writer) {
+    public String getToStringCode(ProblemIOType outputType) {
         // TODO Auto-generated method stub
-
+        return "";
     }
 
     @Override

--- a/src/main/java/com/rocketden/tester/service/generators/JavaDriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/JavaDriverGeneratorService.java
@@ -161,7 +161,7 @@ public class JavaDriverGeneratorService implements DriverGeneratorService {
         }
 
         return String.join("\n",
-                String.format("\tpublic String serialize(%s obj) {", typeInstantiationToString(outputType)),
+                String.format("\tpublic static String serialize(%s obj) {", typeInstantiationToString(outputType)),
                 String.format("\t\treturn %s;", toStringCode),
                 "\t}");
     }

--- a/src/main/java/com/rocketden/tester/service/generators/PythonDriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/PythonDriverGeneratorService.java
@@ -147,8 +147,9 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
 
     @Override
     public String getToStringCode(ProblemIOType outputType) {
-        // TODO Auto-generated method stub
-        return "";
+        return String.join("\n",
+                "def serialize(obj):",
+                "\treturn obj");
     }
 
     @Override
@@ -165,7 +166,7 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
 
         switch (ioType) {
             case STRING:
-                return String.format("\"%s\"", (String) value);
+                return String.format("\"%s\"", value);
             case INTEGER:
                 return String.format("%d", (Integer) value);
             case DOUBLE:

--- a/src/main/java/com/rocketden/tester/service/generators/PythonDriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/PythonDriverGeneratorService.java
@@ -95,8 +95,8 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
     public void writeExecuteTestCases(FileWriter writer, Problem problem) throws IOException {
         // Execute each of the test cases within separate try-catch blocks.
         for (int testNum = 1; testNum <= problem.getTestCases().size(); testNum++) {
-            // Print line to predict any console output.
-            writer.write(String.format("\tprint('Console (%d):')%n", testNum));
+            // Denote beginning of a new test case
+            writer.write(String.format("\tprint('%s')%n", DELIMITER_TEST_CASE));
 
             // Use try-catch block to print any errors.
             writer.write("\ttry:\n");
@@ -123,10 +123,10 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
 
             // Print solution output, catch errors that arise from method call.
             writer.write(String.join("\n",
-                String.format("\t\tprint('Solution (%d):')", testNum),
+                String.format("\t\tprint('%s')", DELIMITER_SUCCESS),
                 String.format("\t\tprint(solution%d)", testNum),
                 "\texcept Exception as e:",
-                String.format("\t\tprint('Error (%d):')", testNum),
+                String.format("\t\tprint('%s')", DELIMITER_FAILURE),
                 "\t\ttraceback.print_exc()\n\n"
             ));
         }

--- a/src/main/java/com/rocketden/tester/service/generators/PythonDriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/PythonDriverGeneratorService.java
@@ -14,6 +14,7 @@ import com.rocketden.tester.model.problem.ProblemInput;
 import com.rocketden.tester.model.problem.ProblemTestCase;
 
 import com.rocketden.tester.service.parsers.InputParser;
+import com.rocketden.tester.service.parsers.OutputParser;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -96,7 +97,7 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
         // Execute each of the test cases within separate try-catch blocks.
         for (int testNum = 1; testNum <= problem.getTestCases().size(); testNum++) {
             // Denote beginning of a new test case
-            writer.write(String.format("\tprint('%s')%n", DELIMITER_TEST_CASE));
+            writer.write(String.format("\tprint('%s')%n", OutputParser.DELIMITER_TEST_CASE));
 
             // Use try-catch block to print any errors.
             writer.write("\ttry:\n");
@@ -123,10 +124,10 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
 
             // Print solution output, catch errors that arise from method call.
             writer.write(String.join("\n",
-                String.format("\t\tprint('%s')", DELIMITER_SUCCESS),
+                String.format("\t\tprint('%s')", OutputParser.DELIMITER_SUCCESS),
                 String.format("\t\tprint(solution%d)", testNum),
                 "\texcept Exception as e:",
-                String.format("\t\tprint('%s')", DELIMITER_FAILURE),
+                String.format("\t\tprint('%s')", OutputParser.DELIMITER_FAILURE),
                 "\t\ttraceback.print_exc()\n\n"
             ));
         }
@@ -141,7 +142,7 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
     }
 
     @Override
-    public void writeToStringCode() {
+    public void writeToStringCode(FileWriter writer) {
         // TODO Auto-generated method stub
 
     }

--- a/src/main/java/com/rocketden/tester/service/generators/PythonDriverGeneratorService.java
+++ b/src/main/java/com/rocketden/tester/service/generators/PythonDriverGeneratorService.java
@@ -33,7 +33,7 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
     public void writeDriverFile(String fileDirectory, Problem problem) {
         // Open writer using try-with-resources.
         try (FileWriter writer = new FileWriter(fileDirectory)) {
-            writeStartingBoilerplate(writer);
+            writeStartingBoilerplate(writer, problem);
             writeTestCases(writer, problem);
             writeExecuteTestCases(writer, problem);
             writeEndingBoilerplate(writer);
@@ -43,12 +43,16 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
     }
 
     @Override
-    public void writeStartingBoilerplate(FileWriter writer) throws IOException {
+    public void writeStartingBoilerplate(FileWriter writer, Problem problem) throws IOException {
         writer.write(String.join("\n",
             "import traceback",
             "import os",
             "os.chdir(os.getcwd())",
             "from Solution import Solution as solution\n",
+            "",
+            "",
+            getToStringCode(problem.getOutputType()),
+            "",
             "def main():\n"
         ));
     }
@@ -125,7 +129,7 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
             // Print solution output, catch errors that arise from method call.
             writer.write(String.join("\n",
                 String.format("\t\tprint('%s')", OutputParser.DELIMITER_SUCCESS),
-                String.format("\t\tprint(solution%d)", testNum),
+                String.format("\t\tprint(serialize(solution%d))", testNum),
                 "\texcept Exception as e:",
                 String.format("\t\tprint('%s')", OutputParser.DELIMITER_FAILURE),
                 "\t\ttraceback.print_exc()\n\n"
@@ -142,9 +146,9 @@ public class PythonDriverGeneratorService implements DriverGeneratorService {
     }
 
     @Override
-    public void writeToStringCode(FileWriter writer) {
+    public String getToStringCode(ProblemIOType outputType) {
         // TODO Auto-generated method stub
-
+        return "";
     }
 
     @Override

--- a/src/main/java/com/rocketden/tester/service/parsers/OutputParser.java
+++ b/src/main/java/com/rocketden/tester/service/parsers/OutputParser.java
@@ -6,6 +6,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class OutputParser {
 
+    public static final String DELIMITER_TEST_CASE = "###########_TEST_CASE_############";
+    public static final String DELIMITER_SUCCESS = "###########_SUCCESS_############";
+    public static final String DELIMITER_FAILURE = "###########_FAILURE_############";
+
     public RunDto parseOutput() {
         // Requires discussion on how output will be stored and read in
 

--- a/src/test/java/com/rocketden/tester/api/JavaTests.java
+++ b/src/test/java/com/rocketden/tester/api/JavaTests.java
@@ -1,5 +1,6 @@
 package com.rocketden.tester.api;
 
+import com.rocketden.tester.service.parsers.OutputParser;
 import com.rocketden.tester.util.ProblemTestMethods;
 import com.rocketden.tester.util.UtilityTestMethods;
 import com.rocketden.tester.dto.RunDto;
@@ -96,8 +97,8 @@ class JavaTests {
         RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
         String expected = String.join("\n",
-                "###########_TEST_CASE_############",
-                "###########_SUCCESS_############",
+                OutputParser.DELIMITER_TEST_CASE,
+                OutputParser.DELIMITER_SUCCESS,
                 "5",
                 "");
 

--- a/src/test/java/com/rocketden/tester/api/JavaTests.java
+++ b/src/test/java/com/rocketden/tester/api/JavaTests.java
@@ -59,11 +59,11 @@ class JavaTests {
         RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
         String expected = String.join("\n",
-                "###########_TEST_CASE_############",
-                "###########_SUCCESS_############",
+                OutputParser.DELIMITER_TEST_CASE,
+                OutputParser.DELIMITER_SUCCESS,
                 "7",
-                "###########_TEST_CASE_############",
-                "###########_SUCCESS_############",
+                OutputParser.DELIMITER_TEST_CASE,
+                OutputParser.DELIMITER_SUCCESS,
                 "16",
                 "");
 

--- a/src/test/java/com/rocketden/tester/api/JavaTests.java
+++ b/src/test/java/com/rocketden/tester/api/JavaTests.java
@@ -58,11 +58,11 @@ class JavaTests {
         RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
         String expected = String.join("\n",
-                "Console (1):",
-                "Solution (1):",
+                "###########_TEST_CASE_############",
+                "###########_SUCCESS_############",
                 "7",
-                "Console (2):",
-                "Solution (2):",
+                "###########_TEST_CASE_############",
+                "###########_SUCCESS_############",
                 "16",
                 "");
 
@@ -96,8 +96,8 @@ class JavaTests {
         RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
         String expected = String.join("\n",
-                "Console (1):",
-                "Solution (1):",
+                "###########_TEST_CASE_############",
+                "###########_SUCCESS_############",
                 "5",
                 "");
 

--- a/src/test/java/com/rocketden/tester/api/PythonTests.java
+++ b/src/test/java/com/rocketden/tester/api/PythonTests.java
@@ -54,11 +54,11 @@ class PythonTests {
 		RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
 		String expected = String.join("\n",
-				"Console (1):",
-				"Solution (1):",
+				"###########_TEST_CASE_############",
+				"###########_SUCCESS_############",
 				"7",
-				"Console (2):",
-				"Solution (2):",
+				"###########_TEST_CASE_############",
+				"###########_SUCCESS_############",
 				"16",
 				"");
 
@@ -90,8 +90,8 @@ class PythonTests {
 		RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
 		String expected = String.join("\n",
-				"Console (1):",
-				"Solution (1):",
+				"###########_TEST_CASE_############",
+				"###########_SUCCESS_############",
 				"5",
 				"");
 

--- a/src/test/java/com/rocketden/tester/api/PythonTests.java
+++ b/src/test/java/com/rocketden/tester/api/PythonTests.java
@@ -1,5 +1,6 @@
 package com.rocketden.tester.api;
 
+import com.rocketden.tester.service.parsers.OutputParser;
 import com.rocketden.tester.util.ProblemTestMethods;
 import com.rocketden.tester.util.UtilityTestMethods;
 import com.rocketden.tester.dto.RunDto;
@@ -90,8 +91,8 @@ class PythonTests {
 		RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
 		String expected = String.join("\n",
-				"###########_TEST_CASE_############",
-				"###########_SUCCESS_############",
+				OutputParser.DELIMITER_TEST_CASE,
+				OutputParser.DELIMITER_SUCCESS,
 				"5",
 				"");
 

--- a/src/test/java/com/rocketden/tester/api/PythonTests.java
+++ b/src/test/java/com/rocketden/tester/api/PythonTests.java
@@ -55,11 +55,11 @@ class PythonTests {
 		RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
 		String expected = String.join("\n",
-				"###########_TEST_CASE_############",
-				"###########_SUCCESS_############",
+				OutputParser.DELIMITER_TEST_CASE,
+				OutputParser.DELIMITER_SUCCESS,
 				"7",
-				"###########_TEST_CASE_############",
-				"###########_SUCCESS_############",
+				OutputParser.DELIMITER_TEST_CASE,
+				OutputParser.DELIMITER_SUCCESS,
 				"16",
 				"");
 

--- a/src/test/java/com/rocketden/tester/service/RunnerServiceTests.java
+++ b/src/test/java/com/rocketden/tester/service/RunnerServiceTests.java
@@ -37,6 +37,7 @@ public class RunnerServiceTests {
 
     @Test
     public void runSuccess() {
+        System.out.println(5 / 0);
         RunRequest request = new RunRequest();
         request.setLanguage(LANGUAGE);
         request.setCode(CODE);

--- a/src/test/java/com/rocketden/tester/service/RunnerServiceTests.java
+++ b/src/test/java/com/rocketden/tester/service/RunnerServiceTests.java
@@ -37,7 +37,6 @@ public class RunnerServiceTests {
 
     @Test
     public void runSuccess() {
-        System.out.println(5 / 0);
         RunRequest request = new RunRequest();
         request.setLanguage(LANGUAGE);
         request.setCode(CODE);

--- a/src/test/java/com/rocketden/tester/service/generators/JavaDriverGeneratorServiceTests.java
+++ b/src/test/java/com/rocketden/tester/service/generators/JavaDriverGeneratorServiceTests.java
@@ -125,6 +125,20 @@ public class JavaDriverGeneratorServiceTests {
 
     @Test
     public void getToStringCodeSuccess() {
+        String code = String.join("\n",
+                "    public String serialize(int[] obj) {",
+                "        return Arrays.toString(obj);",
+                "    }");
 
+        String generatedCode = service.getToStringCode(ProblemIOType.ARRAY_INTEGER);
+        assertEquals(code, generatedCode.replaceAll("\t", "    "));
+
+        code = String.join("\n",
+                "    public String serialize(double obj) {",
+                "        return String.valueOf(obj);",
+                "    }");
+
+        generatedCode = service.getToStringCode(ProblemIOType.DOUBLE);
+        assertEquals(code, generatedCode.replaceAll("\t", "    "));
     }
 }

--- a/src/test/java/com/rocketden/tester/service/generators/JavaDriverGeneratorServiceTests.java
+++ b/src/test/java/com/rocketden/tester/service/generators/JavaDriverGeneratorServiceTests.java
@@ -121,6 +121,10 @@ public class JavaDriverGeneratorServiceTests {
         ApiException exception = assertThrows(ApiException.class, () ->
             service.typeInitializationToString(ProblemIOType.STRING, CHARACTER_INPUT));
         assertEquals(ProblemError.OBJECT_MATCH_IOTYPE, exception.getError());
-        ;
+    }
+
+    @Test
+    public void getToStringCodeSuccess() {
+
     }
 }

--- a/src/test/java/com/rocketden/tester/service/generators/JavaDriverGeneratorServiceTests.java
+++ b/src/test/java/com/rocketden/tester/service/generators/JavaDriverGeneratorServiceTests.java
@@ -126,7 +126,7 @@ public class JavaDriverGeneratorServiceTests {
     @Test
     public void getToStringCodeSuccess() {
         String code = String.join("\n",
-                "    public String serialize(int[] obj) {",
+                "    public static String serialize(int[] obj) {",
                 "        return Arrays.toString(obj);",
                 "    }");
 
@@ -134,7 +134,7 @@ public class JavaDriverGeneratorServiceTests {
         assertEquals(code, generatedCode.replaceAll("\t", "    "));
 
         code = String.join("\n",
-                "    public String serialize(double obj) {",
+                "    public static String serialize(double obj) {",
                 "        return String.valueOf(obj);",
                 "    }");
 

--- a/src/test/java/com/rocketden/tester/service/generators/PythonDriverGeneratorServiceTests.java
+++ b/src/test/java/com/rocketden/tester/service/generators/PythonDriverGeneratorServiceTests.java
@@ -118,7 +118,18 @@ public class PythonDriverGeneratorServiceTests {
 
     @Test
     public void getToStringCodeSuccess() {
+        String code = String.join("\n",
+                "def serialize(obj):",
+                "    return obj");
 
+        String generatedCode = service.getToStringCode(ProblemIOType.STRING);
+        assertEquals(code, generatedCode.replaceAll("\t", "    "));
+
+        generatedCode = service.getToStringCode(ProblemIOType.ARRAY_BOOLEAN);
+        assertEquals(code, generatedCode.replaceAll("\t", "    "));
+
+        generatedCode = service.getToStringCode(ProblemIOType.CHARACTER);
+        assertEquals(code, generatedCode.replaceAll("\t", "    "));
     }
 
 }

--- a/src/test/java/com/rocketden/tester/service/generators/PythonDriverGeneratorServiceTests.java
+++ b/src/test/java/com/rocketden/tester/service/generators/PythonDriverGeneratorServiceTests.java
@@ -114,6 +114,11 @@ public class PythonDriverGeneratorServiceTests {
         ApiException exception = assertThrows(ApiException.class, () ->
             service.typeInitializationToString(ProblemIOType.STRING, CHARACTER_INPUT));
         assertEquals(ProblemError.OBJECT_MATCH_IOTYPE, exception.getError());
-        ;
     }
+
+    @Test
+    public void getToStringCodeSuccess() {
+
+    }
+
 }


### PR DESCRIPTION
### List of Changes:

* Create delimiters to separate driver program test cases and outputs
* Implement serialization method for printing return objects in Java and Python
* Update README with up-to-date info on new serialization format
* Add new tests to cover the `getToStringCode` method 

### Notes:

* We originally decided to just compare the serialized strings to judge outputs, but I feel like this may be too difficult to deal with. Mainly, I think it would require us to serialize every object type in each language exactly the same, as well as ensure that when people create problem outputs (i.e. the correct answers), they also manually follow the same format, which just seems a bit too brittle of a system
* As a result I'm thinking it would be good if we read in the serialized objects (again using JSON, possibly reusing the private InputParser method since it's all the same format) - however I'm open to talking about this and seeing what would actually be best
* This PR is to be followed by the code for parsing the serialized output into Java and then construct a RunDto object from the results (with things like numCorrect, etc.)
