### PR TITLE
Parse the output to create updated RunDto object.

### DIFF
--- a/src/main/java/com/rocketden/tester/dto/ResultDto.java
+++ b/src/main/java/com/rocketden/tester/dto/ResultDto.java
@@ -1,0 +1,30 @@
+package com.rocketden.tester.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResultDto {
+    private String console;
+    private String userOutput;
+    private String error;
+    private String correctOutput;
+    private boolean correct;
+}
+
+
+
+/**
+
+There should be an object that has the console / output / error for each method.
+For any result, either the output or the error exists while the other is null.
+Maybe a <ResultDto>, with the above fields.
+Perhaps this object also holds the correct solution, as well as booleans.
+I could also include the PlayerCode object, though I'm uncertain if matters.
+Long runtime as well.
+I should use startTime, numCorrect, and numTestCases as well.
+
+These are in a List that match
+
+ */

--- a/src/main/java/com/rocketden/tester/dto/ResultDto.java
+++ b/src/main/java/com/rocketden/tester/dto/ResultDto.java
@@ -12,19 +12,3 @@ public class ResultDto {
     private String correctOutput;
     private boolean correct;
 }
-
-
-
-/**
-
-There should be an object that has the console / output / error for each method.
-For any result, either the output or the error exists while the other is null.
-Maybe a <ResultDto>, with the above fields.
-Perhaps this object also holds the correct solution, as well as booleans.
-I could also include the PlayerCode object, though I'm uncertain if matters.
-Long runtime as well.
-I should use startTime, numCorrect, and numTestCases as well.
-
-These are in a List that match
-
- */

--- a/src/main/java/com/rocketden/tester/dto/RunDto.java
+++ b/src/main/java/com/rocketden/tester/dto/RunDto.java
@@ -1,9 +1,7 @@
 package com.rocketden.tester.dto;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
-import com.rocketden.tester.model.Language;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -12,10 +10,7 @@ import lombok.Setter;
 @Setter
 public class RunDto {
     private List<ResultDto> results;
-    private String code;
-    private Language language;
     private Integer numCorrect;
     private Integer numTestCases;
     private Long runtime;
-    private LocalDateTime startTime;
 }

--- a/src/main/java/com/rocketden/tester/dto/RunDto.java
+++ b/src/main/java/com/rocketden/tester/dto/RunDto.java
@@ -11,7 +11,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class RunDto {
-    private boolean status;
     private List<ResultDto> results;
     private String code;
     private Language language;

--- a/src/main/java/com/rocketden/tester/dto/RunDto.java
+++ b/src/main/java/com/rocketden/tester/dto/RunDto.java
@@ -1,5 +1,10 @@
 package com.rocketden.tester.dto;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.rocketden.tester.model.Language;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,5 +12,11 @@ import lombok.Setter;
 @Setter
 public class RunDto {
     private boolean status;
-    private String output;
+    private List<ResultDto> results;
+    private String code;
+    private Language language;
+    private Integer numCorrect;
+    private Integer numTestCases;
+    private Long runtime;
+    private LocalDateTime startTime;
 }

--- a/src/main/java/com/rocketden/tester/exception/ParserError.java
+++ b/src/main/java/com/rocketden/tester/exception/ParserError.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum ParserError implements ApiError {
 
     INCORRECT_COUNT(HttpStatus.BAD_REQUEST, "Please specify the correct number of inputs for ths problem."),
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, "Please ensure each line of input is valid and is of the correct type.");
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "Please ensure each line of input is valid and is of the correct type."),
+    BAD_SECTION(HttpStatus.BAD_REQUEST, "Please choose a valid ouptut section."),
+    MISFORMATTED_OUTPUT(HttpStatus.INTERNAL_SERVER_ERROR, "The output from the user's code is misformatted, and thus cannot be parsed accurately.");
 
     private final HttpStatus status;
     private final ApiErrorResponse response;

--- a/src/main/java/com/rocketden/tester/model/OutputSection.java
+++ b/src/main/java/com/rocketden/tester/model/OutputSection.java
@@ -1,0 +1,24 @@
+package com.rocketden.tester.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.rocketden.tester.exception.ParserError;
+import com.rocketden.tester.exception.api.ApiException;
+
+public enum OutputSection {
+
+    TEST_CASE,
+    SUCCESS,
+    FAILURE,
+    START;
+
+    // Convert a matching string (ignoring case) to enum object
+    @JsonCreator
+    public static Language fromString(String value) {
+        try {
+            return Language.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new ApiException(ParserError.BAD_SECTION);
+        }
+    }
+    
+}

--- a/src/main/java/com/rocketden/tester/service/DockerService.java
+++ b/src/main/java/com/rocketden/tester/service/DockerService.java
@@ -98,8 +98,6 @@ public class DockerService {
             throw new ApiException(ParserError.MISFORMATTED_OUTPUT);
         }
 
-        boolean exitStatus = process.waitFor(TIME_LIMIT, TimeUnit.SECONDS);
-
         RunDto runDto = new RunDto();
         runDto.setResults(results);
 

--- a/src/main/java/com/rocketden/tester/service/DockerService.java
+++ b/src/main/java/com/rocketden/tester/service/DockerService.java
@@ -1,15 +1,20 @@
 package com.rocketden.tester.service;
 
+import com.rocketden.tester.dto.ResultDto;
 import com.rocketden.tester.dto.RunDto;
 import com.rocketden.tester.exception.DockerSetupError;
 import com.rocketden.tester.exception.api.ApiException;
 import com.rocketden.tester.model.Language;
+import com.rocketden.tester.model.problem.Problem;
+import com.rocketden.tester.model.problem.ProblemTestCase;
 
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -17,7 +22,11 @@ public class DockerService {
 
     private static final int TIME_LIMIT = 2;
 
-    public RunDto spawnAndRun(String folder, Language language) {
+    public static final String DELIMITER_TEST_CASE = "###########_TEST_CASE_############";
+    public static final String DELIMITER_SUCCESS = "###########_SUCCESS_############";
+    public static final String DELIMITER_FAILURE = "###########_FAILURE_############";
+
+    public RunDto spawnAndRun(String folder, Language language, Problem problem) {
         try {
             // Create and run disposable docker container with the given temp folder
             String[] commands = getRunCommands(folder, language);
@@ -25,7 +34,7 @@ public class DockerService {
             builder.redirectErrorStream(true);
             Process process = builder.start();
 
-            return captureOutput(process);
+            return captureOutput(process, problem);
 
         } catch (Exception e) {
             throw new ApiException(DockerSetupError.BUILD_DOCKER_CONTAINER);
@@ -33,21 +42,36 @@ public class DockerService {
     }
 
     // Given a process, return its status, console output, and error output
-    private RunDto captureOutput(Process process) throws IOException, InterruptedException {
+    private RunDto captureOutput(Process process, Problem problem) throws IOException, InterruptedException {
         BufferedReader stdInput = new BufferedReader(new
                 InputStreamReader(process.getInputStream()));
 
+        List<ProblemTestCase> testCases = problem.getTestCases();
+
+        // Create the List of ResultDto objects.
         StringBuilder output = new StringBuilder();
+        int testCase = 0;
         String s;
         while ((s = stdInput.readLine()) != null) {
             output.append(s).append("\n");
+            if (output.equals(DELIMITER_TEST_CASE)) {
+                
+            }
         }
 
         boolean exitStatus = process.waitFor(TIME_LIMIT, TimeUnit.SECONDS);
 
         RunDto runDto = new RunDto();
         runDto.setStatus(exitStatus);
-        runDto.setOutput(output.toString());
+        runDto.setResults(null);
+
+        // Set the number of correct test cases.
+        runDto.setNumCorrect(10);
+        runDto.setNumTestCases(testCases.size());
+
+        // Set the output manually, before the runtime is calculated.
+        runDto.setRuntime(0L);
+        runDto.setStartTime(LocalDateTime.now());
 
         return runDto;
     }
@@ -55,5 +79,10 @@ public class DockerService {
     private String[] getRunCommands(String folder, Language language) {
         String mountPath = String.format("%s:/code", folder);
         return new String[] {"docker", "run", "--rm", "-v", mountPath, "-t", language.getDockerContainer()};
+    }
+
+    // Return whether the user's output is correct.
+    private boolean isCorrect(String output, ProblemTestCase testCase) {
+        return true;
     }
 }

--- a/src/main/java/com/rocketden/tester/service/DockerService.java
+++ b/src/main/java/com/rocketden/tester/service/DockerService.java
@@ -1,23 +1,13 @@
 package com.rocketden.tester.service;
 
-import com.rocketden.tester.dto.ResultDto;
 import com.rocketden.tester.dto.RunDto;
 import com.rocketden.tester.exception.DockerSetupError;
-import com.rocketden.tester.exception.ParserError;
 import com.rocketden.tester.exception.api.ApiException;
 import com.rocketden.tester.model.Language;
-import com.rocketden.tester.model.OutputSection;
 import com.rocketden.tester.model.problem.Problem;
-import com.rocketden.tester.model.problem.ProblemTestCase;
 import com.rocketden.tester.service.parsers.OutputParser;
 
 import org.springframework.stereotype.Service;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 public class DockerService {
@@ -30,126 +20,16 @@ public class DockerService {
             builder.redirectErrorStream(true);
             Process process = builder.start();
 
-            return parseCaptureOutput(process, problem);
+            OutputParser outputParser = new OutputParser();
+            return outputParser.parseCaptureOutput(process, problem);
 
         } catch (Exception e) {
             throw new ApiException(DockerSetupError.BUILD_DOCKER_CONTAINER);
         }
     }
 
-    /**
-     * Given a process and the relevant problem, parse and produce
-     * the relevant RunDto object to capture the console, solution, and
-     * errors for each test case, as well as the correctness and runtime.
-     * 
-     * @param process The process used to get the testing output.
-     * @param problem The current problem associated with this output.
-     * @return The RunDto object produced from the output.
-     */
-    private RunDto parseCaptureOutput(Process process, Problem problem) throws IOException {
-        BufferedReader stdInput = new BufferedReader(new
-                InputStreamReader(process.getInputStream()));
-
-        List<ProblemTestCase> testCases = problem.getTestCases();
-
-        // Create the List of ResultDto objects.
-        List<ResultDto> results = new ArrayList<>();
-        ResultDto result = new ResultDto();
-        StringBuilder output = new StringBuilder();
-        OutputSection outputSection = OutputSection.START;
-        int numCorrect = 0;
-        String s;
-        while ((s = stdInput.readLine()) != null) {
-            // Update the output section.
-            if (s.equals(OutputParser.DELIMITER_TEST_CASE)) {
-                parseTestCaseOutput(outputSection,
-                    output.toString(), results, result,
-                    testCases.get(results.size()));
-                output.setLength(0);
-                outputSection = OutputSection.TEST_CASE;
-            } else if (s.equals(OutputParser.DELIMITER_SUCCESS)) {
-                // Update the result as expected or throw error if misformatted.
-                if (outputSection != OutputSection.TEST_CASE) {
-                    throw new ApiException(ParserError.MISFORMATTED_OUTPUT);
-                }
-
-                result.setConsole(output.toString());
-                outputSection = OutputSection.SUCCESS;
-            } else if (s.equals(OutputParser.DELIMITER_FAILURE)) {
-                // Update the result as expected or throw error if misformatted.
-                if (outputSection != OutputSection.TEST_CASE) {
-                    throw new ApiException(ParserError.MISFORMATTED_OUTPUT);
-                }
-
-                result.setConsole(output.toString());
-                outputSection = OutputSection.FAILURE;
-            } else {
-                // Append new line to output, if line is not a delimiter.
-                output.append(s).append("\n");
-            }
-        }
-
-        // Throw error if more tests were captured than exist.
-        if (results.size() != testCases.size()) {
-            throw new ApiException(ParserError.MISFORMATTED_OUTPUT);
-        }
-
-        RunDto runDto = new RunDto();
-        runDto.setResults(results);
-
-        // Set the number of correct test cases.
-        runDto.setNumCorrect(numCorrect);
-        runDto.setNumTestCases(testCases.size());
-
-        // Set the output manually, before the runtime is calculated.
-        runDto.setRuntime(0L);
-
-        return runDto;
-    }
-
     private String[] getRunCommands(String folder, Language language) {
         String mountPath = String.format("%s:/code", folder);
         return new String[] {"docker", "run", "--rm", "-v", mountPath, "-t", language.getDockerContainer()};
-    }
-
-    // Return whether the user's output is correct.
-    private boolean isOutputCorrect(String output, ProblemTestCase testCase) {
-        return output.equals(testCase.getOutput());
-    }
-
-    /**
-     * Handle the update to parse the test case output.
-     * 
-     * @param outputSection The current output section in the parsing process.
-     * @param outputStr The current output, in String form.
-     * @param results The list of results, which this method adds to.
-     * @param result The current result being built, and possibly added to
-     * the results object.
-     * @param testCase The relevant test case for this parsing step.
-     */
-    private void parseTestCaseOutput(OutputSection outputSection,
-        String outputStr, List<ResultDto> results, ResultDto result,
-        ProblemTestCase testCase) {
-        // Update the result as expected or throw error if misformatted.
-        if (outputSection == OutputSection.TEST_CASE) {
-            throw new ApiException(ParserError.MISFORMATTED_OUTPUT);
-        } else if (outputSection == OutputSection.SUCCESS) {
-            // Set the result fields.
-            result.setUserOutput(outputStr);
-            result.setError(null);
-            result.setCorrectOutput(testCase.getOutput());
-
-            // Set the output correctness.
-            boolean outputCorrect = isOutputCorrect(outputStr, testCase);
-            result.setCorrect(outputCorrect);
-            results.add(result);
-        } else if (outputSection == OutputSection.FAILURE) {
-            // Set the result fields.
-            result.setUserOutput(null);
-            result.setError(outputStr);
-            result.setCorrectOutput(testCase.getOutput());
-            result.setCorrect(false);
-            results.add(result);
-        }
     }
 }

--- a/src/main/java/com/rocketden/tester/service/DockerService.java
+++ b/src/main/java/com/rocketden/tester/service/DockerService.java
@@ -7,10 +7,18 @@ import com.rocketden.tester.model.Language;
 import com.rocketden.tester.model.problem.Problem;
 import com.rocketden.tester.service.parsers.OutputParser;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class DockerService {
+
+    private final OutputParser outputParser;
+
+    @Autowired
+    public DockerService(OutputParser outputParser) {
+        this.outputParser = outputParser;
+    }
 
     public RunDto spawnAndRun(String folder, Language language, Problem problem) {
         try {
@@ -20,7 +28,7 @@ public class DockerService {
             builder.redirectErrorStream(true);
             Process process = builder.start();
 
-            OutputParser outputParser = new OutputParser();
+            // Parse, capture, and return the newly-created RunDto object.
             return outputParser.parseCaptureOutput(process, problem);
 
         } catch (Exception e) {

--- a/src/main/java/com/rocketden/tester/service/DockerService.java
+++ b/src/main/java/com/rocketden/tester/service/DockerService.java
@@ -148,6 +148,6 @@ public class DockerService {
 
     // Return whether the user's output is correct.
     private boolean isOutputCorrect(String output, ProblemTestCase testCase) {
-        return true;
+        return output.equals(testCase.getOutput());
     }
 }

--- a/src/main/java/com/rocketden/tester/service/DockerService.java
+++ b/src/main/java/com/rocketden/tester/service/DockerService.java
@@ -16,15 +16,11 @@ import org.springframework.stereotype.Service;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 @Service
 public class DockerService {
-
-    private static final int TIME_LIMIT = 2;
 
     public RunDto spawnAndRun(String folder, Language language, Problem problem) {
         try {
@@ -50,7 +46,7 @@ public class DockerService {
      * @param problem The current problem associated with this output.
      * @return The RunDto object produced from the output.
      */
-    private RunDto parseCaptureOutput(Process process, Problem problem) throws IOException, InterruptedException {
+    private RunDto parseCaptureOutput(Process process, Problem problem) throws IOException {
         BufferedReader stdInput = new BufferedReader(new
                 InputStreamReader(process.getInputStream()));
 
@@ -107,7 +103,6 @@ public class DockerService {
 
         // Set the output manually, before the runtime is calculated.
         runDto.setRuntime(0L);
-        runDto.setStartTime(LocalDateTime.now());
 
         return runDto;
     }

--- a/src/main/java/com/rocketden/tester/service/RunnerService.java
+++ b/src/main/java/com/rocketden/tester/service/RunnerService.java
@@ -44,7 +44,12 @@ public class RunnerService {
         String folder = setupService.createTempFolder();
         try {
             setupService.populateTempFolder(folder, request);
-            return dockerService.spawnAndRun(folder, request.getLanguage(), problem);
+
+            // Get RunDto and set the remaining fields.
+            RunDto runDto = dockerService.spawnAndRun(folder, request.getLanguage(), problem);
+            runDto.setCode(request.getCode());
+            runDto.setLanguage(request.getLanguage());
+            return runDto;
         } finally {
             // Clean up temp folder regardless if above code throws an exception
             setupService.deleteTempFolder(folder);

--- a/src/main/java/com/rocketden/tester/service/RunnerService.java
+++ b/src/main/java/com/rocketden/tester/service/RunnerService.java
@@ -44,12 +44,7 @@ public class RunnerService {
         String folder = setupService.createTempFolder();
         try {
             setupService.populateTempFolder(folder, request);
-
-            // Get RunDto and set the remaining fields.
-            RunDto runDto = dockerService.spawnAndRun(folder, request.getLanguage(), problem);
-            runDto.setCode(request.getCode());
-            runDto.setLanguage(request.getLanguage());
-            return runDto;
+            return dockerService.spawnAndRun(folder, request.getLanguage(), problem);
         } finally {
             // Clean up temp folder regardless if above code throws an exception
             setupService.deleteTempFolder(folder);

--- a/src/main/java/com/rocketden/tester/service/RunnerService.java
+++ b/src/main/java/com/rocketden/tester/service/RunnerService.java
@@ -44,7 +44,7 @@ public class RunnerService {
         String folder = setupService.createTempFolder();
         try {
             setupService.populateTempFolder(folder, request);
-            return dockerService.spawnAndRun(folder, request.getLanguage());
+            return dockerService.spawnAndRun(folder, request.getLanguage(), problem);
         } finally {
             // Clean up temp folder regardless if above code throws an exception
             setupService.deleteTempFolder(folder);

--- a/src/main/java/com/rocketden/tester/service/parsers/OutputParser.java
+++ b/src/main/java/com/rocketden/tester/service/parsers/OutputParser.java
@@ -1,6 +1,19 @@
 package com.rocketden.tester.service.parsers;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.rocketden.tester.dto.ResultDto;
 import com.rocketden.tester.dto.RunDto;
+import com.rocketden.tester.exception.ParserError;
+import com.rocketden.tester.exception.api.ApiException;
+import com.rocketden.tester.model.OutputSection;
+import com.rocketden.tester.model.problem.Problem;
+import com.rocketden.tester.model.problem.ProblemTestCase;
+
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,9 +23,114 @@ public class OutputParser {
     public static final String DELIMITER_SUCCESS = "###########_SUCCESS_############";
     public static final String DELIMITER_FAILURE = "###########_FAILURE_############";
 
-    public RunDto parseOutput() {
-        // Requires discussion on how output will be stored and read in
+    /**
+     * Given a process and the relevant problem, parse and produce
+     * the relevant RunDto object to capture the console, solution, and
+     * errors for each test case, as well as the correctness and runtime.
+     * 
+     * @param process The process used to get the testing output.
+     * @param problem The current problem associated with this output.
+     * @return The RunDto object produced from the output.
+     */
+    public RunDto parseCaptureOutput(Process process, Problem problem) throws IOException {
+        BufferedReader stdInput = new BufferedReader(new
+                InputStreamReader(process.getInputStream()));
 
-        return null;
+        List<ProblemTestCase> testCases = problem.getTestCases();
+
+        // Create the List of ResultDto objects.
+        List<ResultDto> results = new ArrayList<>();
+        ResultDto result = new ResultDto();
+        StringBuilder output = new StringBuilder();
+        OutputSection outputSection = OutputSection.START;
+        int numCorrect = 0;
+        String s;
+        while ((s = stdInput.readLine()) != null) {
+            // Update the output section.
+            if (s.equals(DELIMITER_TEST_CASE)) {
+                parseTestCaseOutput(outputSection,
+                    output.toString(), results, result,
+                    testCases.get(results.size()));
+                output.setLength(0);
+                outputSection = OutputSection.TEST_CASE;
+            } else if (s.equals(DELIMITER_SUCCESS)) {
+                // Update the result as expected or throw error if misformatted.
+                if (outputSection != OutputSection.TEST_CASE) {
+                    throw new ApiException(ParserError.MISFORMATTED_OUTPUT);
+                }
+
+                result.setConsole(output.toString());
+                outputSection = OutputSection.SUCCESS;
+            } else if (s.equals(DELIMITER_FAILURE)) {
+                // Update the result as expected or throw error if misformatted.
+                if (outputSection != OutputSection.TEST_CASE) {
+                    throw new ApiException(ParserError.MISFORMATTED_OUTPUT);
+                }
+
+                result.setConsole(output.toString());
+                outputSection = OutputSection.FAILURE;
+            } else {
+                // Append new line to output, if line is not a delimiter.
+                output.append(s).append("\n");
+            }
+        }
+
+        // Throw error if more tests were captured than exist.
+        if (results.size() != testCases.size()) {
+            throw new ApiException(ParserError.MISFORMATTED_OUTPUT);
+        }
+
+        RunDto runDto = new RunDto();
+        runDto.setResults(results);
+
+        // Set the number of correct test cases.
+        runDto.setNumCorrect(numCorrect);
+        runDto.setNumTestCases(testCases.size());
+
+        // Set the output manually, before the runtime is calculated.
+        runDto.setRuntime(0L);
+
+        return runDto;
+    }
+
+    /**
+     * Handle the update to parse the test case output.
+     * 
+     * @param outputSection The current output section in the parsing process.
+     * @param outputStr The current output, in String form.
+     * @param results The list of results, which this method adds to.
+     * @param result The current result being built, and possibly added to
+     * the results object.
+     * @param testCase The relevant test case for this parsing step.
+     */
+    private void parseTestCaseOutput(OutputSection outputSection,
+        String outputStr, List<ResultDto> results, ResultDto result,
+        ProblemTestCase testCase) {
+        // Update the result as expected or throw error if misformatted.
+        if (outputSection == OutputSection.TEST_CASE) {
+            throw new ApiException(ParserError.MISFORMATTED_OUTPUT);
+        } else if (outputSection == OutputSection.SUCCESS) {
+            // Set the result fields.
+            result.setUserOutput(outputStr);
+            result.setError(null);
+            result.setCorrectOutput(testCase.getOutput());
+
+            // Set the output correctness.
+            boolean outputCorrect = isOutputCorrect(outputStr, testCase);
+            result.setCorrect(outputCorrect);
+            results.add(result);
+        } else if (outputSection == OutputSection.FAILURE) {
+            // Set the result fields.
+            result.setUserOutput(null);
+            result.setError(outputStr);
+            result.setCorrectOutput(testCase.getOutput());
+            result.setCorrect(false);
+            results.add(result);
+        }
+    }
+
+    // Return whether the user's output is correct.
+    private boolean isOutputCorrect(String output, ProblemTestCase testCase) {
+        return output.equals(testCase.getOutput());
     }
 }

--- a/src/main/java/com/rocketden/tester/service/parsers/OutputParser.java
+++ b/src/main/java/com/rocketden/tester/service/parsers/OutputParser.java
@@ -60,6 +60,7 @@ public class OutputParser {
                 }
 
                 result.setConsole(output.toString());
+                output.setLength(0);
                 outputSection = OutputSection.SUCCESS;
             } else if (s.equals(DELIMITER_FAILURE)) {
                 // Update the result as expected or throw error if misformatted.
@@ -68,6 +69,7 @@ public class OutputParser {
                 }
 
                 result.setConsole(output.toString());
+                output.setLength(0);
                 outputSection = OutputSection.FAILURE;
             } else {
                 // Append new line to output, if line is not a delimiter.

--- a/src/main/java/com/rocketden/tester/service/parsers/OutputParser.java
+++ b/src/main/java/com/rocketden/tester/service/parsers/OutputParser.java
@@ -75,6 +75,11 @@ public class OutputParser {
             }
         }
 
+        // Add the last remaining test case output, if one exists.
+        parseTestCaseOutput(outputSection,
+            output.toString(), results, result,
+            testCases.get(results.size()));
+
         // Throw error if more tests were captured than exist.
         if (results.size() != testCases.size()) {
             throw new ApiException(ParserError.MISFORMATTED_OUTPUT);

--- a/src/main/java/com/rocketden/tester/service/parsers/OutputParser.java
+++ b/src/main/java/com/rocketden/tester/service/parsers/OutputParser.java
@@ -51,6 +51,7 @@ public class OutputParser {
                 numCorrect = parseTestCaseOutput(outputSection,
                     output.toString(), results, result,
                     testCases.get(results.size()), numCorrect);
+                result = new ResultDto();
                 output.setLength(0);
                 outputSection = OutputSection.TEST_CASE;
             } else if (s.equals(DELIMITER_SUCCESS)) {

--- a/src/test/java/com/rocketden/tester/api/JavaTests.java
+++ b/src/test/java/com/rocketden/tester/api/JavaTests.java
@@ -14,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -57,17 +56,8 @@ class JavaTests {
         String response = result.getResponse().getContentAsString();
         RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
-        String expected = String.join("\n",
-                "Console (1):",
-                "Solution (1):",
-                "7",
-                "Console (2):",
-                "Solution (2):",
-                "16",
-                "");
-
         assertTrue(runDto.isStatus());
-        assertEquals(expected, runDto.getOutput());
+        // TODO: Check the RunDto expected fields.
     }
 
     @Test
@@ -95,14 +85,8 @@ class JavaTests {
         String response = result.getResponse().getContentAsString();
         RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
-        String expected = String.join("\n",
-                "Console (1):",
-                "Solution (1):",
-                "5",
-                "");
-
         assertTrue(runDto.isStatus());
-        assertEquals(expected, runDto.getOutput());
+        // TODO: Check the RunDto expected fields.
     }
 
     @Test

--- a/src/test/java/com/rocketden/tester/api/JavaTests.java
+++ b/src/test/java/com/rocketden/tester/api/JavaTests.java
@@ -14,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -56,7 +55,6 @@ class JavaTests {
         String response = result.getResponse().getContentAsString();
         RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
-        assertTrue(runDto.isStatus());
         // TODO: Check the RunDto expected fields.
     }
 
@@ -85,7 +83,6 @@ class JavaTests {
         String response = result.getResponse().getContentAsString();
         RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
-        assertTrue(runDto.isStatus());
         // TODO: Check the RunDto expected fields.
     }
 

--- a/src/test/java/com/rocketden/tester/api/PythonTests.java
+++ b/src/test/java/com/rocketden/tester/api/PythonTests.java
@@ -66,7 +66,7 @@ class PythonTests {
 		request.setCode(code);
 		request.setLanguage(LANGUAGE);
 
-		Problem problem = ProblemTestMethods.getSumProblem("2", "3");
+		Problem problem = ProblemTestMethods.getSumProblem("2\n3\n");
 		request.setProblem(problem);
 
 		MvcResult result = this.mockMvc.perform(post(POST_RUNNER)

--- a/src/test/java/com/rocketden/tester/api/PythonTests.java
+++ b/src/test/java/com/rocketden/tester/api/PythonTests.java
@@ -14,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -50,9 +49,8 @@ class PythonTests {
 				.andReturn();
 
 		String response = result.getResponse().getContentAsString();
-		RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
-
-        assertTrue(runDto.isStatus());
+        RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
+        
         // TODO: Check the RunDto expected fields.
 	}
 
@@ -79,7 +77,6 @@ class PythonTests {
 		String response = result.getResponse().getContentAsString();
 		RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
-		assertTrue(runDto.isStatus());
 		// TODO: Check the RunDto expected fields.
 	}
 

--- a/src/test/java/com/rocketden/tester/api/PythonTests.java
+++ b/src/test/java/com/rocketden/tester/api/PythonTests.java
@@ -31,7 +31,8 @@ class PythonTests {
 	private static final String CODE = String.join("\n",
 			"class Solution:",
 			"    def solve(array):",
-			"        return max(array)");
+            "        return max(array)");
+    private static final String ERROR_CODE = "class Solution(object):\n\tdef solve(num):\n\t\tlist = [1, 2, 4]\n\t\tprint(num)\n\t\treturn list[num]";
 
 	@Test
 	public void runRequestSuccess() throws Exception {
@@ -65,7 +66,7 @@ class PythonTests {
 		request.setCode(code);
 		request.setLanguage(LANGUAGE);
 
-		Problem problem = ProblemTestMethods.getSumProblem("\n2\n3");
+		Problem problem = ProblemTestMethods.getSumProblem("2", "3");
 		request.setProblem(problem);
 
 		MvcResult result = this.mockMvc.perform(post(POST_RUNNER)
@@ -78,6 +79,27 @@ class PythonTests {
 		RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
 		// TODO: Check the RunDto expected fields.
+    }
+    
+    @Test
+	public void runRequestFailureOnTwoCases() throws Exception {
+		RunRequest request = new RunRequest();
+		request.setCode(ERROR_CODE);
+		request.setLanguage(LANGUAGE);
+
+		Problem problem = ProblemTestMethods.getMultiplyDoubleProblem("2", "5", "13");
+		request.setProblem(problem);
+
+		MvcResult result = this.mockMvc.perform(post(POST_RUNNER)
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.content(UtilityTestMethods.convertObjectToJsonString(request)))
+				.andDo(print()).andExpect(status().isOk())
+				.andReturn();
+
+		String response = result.getResponse().getContentAsString();
+        RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
+        
+        // TODO: Check the RunDto expected fields.
 	}
 
 	@Test

--- a/src/test/java/com/rocketden/tester/api/PythonTests.java
+++ b/src/test/java/com/rocketden/tester/api/PythonTests.java
@@ -14,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -53,17 +52,8 @@ class PythonTests {
 		String response = result.getResponse().getContentAsString();
 		RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
-		String expected = String.join("\n",
-				"Console (1):",
-				"Solution (1):",
-				"7",
-				"Console (2):",
-				"Solution (2):",
-				"16",
-				"");
-
-		assertTrue(runDto.isStatus());
-		assertEquals(expected, runDto.getOutput());
+        assertTrue(runDto.isStatus());
+        // TODO: Check the RunDto expected fields.
 	}
 
 	@Test
@@ -89,14 +79,8 @@ class PythonTests {
 		String response = result.getResponse().getContentAsString();
 		RunDto runDto = UtilityTestMethods.toObject(response, RunDto.class);
 
-		String expected = String.join("\n",
-				"Console (1):",
-				"Solution (1):",
-				"5",
-				"");
-
 		assertTrue(runDto.isStatus());
-		assertEquals(expected, runDto.getOutput());
+		// TODO: Check the RunDto expected fields.
 	}
 
 	@Test

--- a/src/test/java/com/rocketden/tester/service/RunnerServiceTests.java
+++ b/src/test/java/com/rocketden/tester/service/RunnerServiceTests.java
@@ -5,6 +5,7 @@ import com.rocketden.tester.exception.DockerSetupError;
 import com.rocketden.tester.exception.api.ApiError;
 import com.rocketden.tester.exception.api.ApiException;
 import com.rocketden.tester.model.Language;
+import com.rocketden.tester.model.problem.Problem;
 import com.rocketden.tester.util.ProblemTestMethods;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,13 +41,15 @@ public class RunnerServiceTests {
         RunRequest request = new RunRequest();
         request.setLanguage(LANGUAGE);
         request.setCode(CODE);
-        request.setProblem(ProblemTestMethods.getFindMaxProblem("[]"));
+
+        Problem problem = ProblemTestMethods.getFindMaxProblem("[]");
+        request.setProblem(problem);
 
         Mockito.doReturn(TEMP_FOLDER).when(setupService).createTempFolder();
         runnerService.run(request);
 
         verify(setupService).populateTempFolder(TEMP_FOLDER, request);
-        verify(dockerService).spawnAndRun(TEMP_FOLDER, request.getLanguage());
+        verify(dockerService).spawnAndRun(TEMP_FOLDER, request.getLanguage(), problem);
         verify(setupService).deleteTempFolder(TEMP_FOLDER);
     }
 

--- a/src/test/java/com/rocketden/tester/util/ProblemTestMethods.java
+++ b/src/test/java/com/rocketden/tester/util/ProblemTestMethods.java
@@ -60,4 +60,27 @@ public class ProblemTestMethods {
 
         return problem;
     }
+
+    public static Problem getMultiplyDoubleProblem(String... inputs) {
+        List<ProblemTestCase> testCases = new ArrayList<>();
+
+        for (String input : inputs) {
+            ProblemTestCase testCase = new ProblemTestCase();
+            testCase.setInput(input);
+            testCases.add(testCase);
+        }
+
+        List<ProblemInput> problemInputs = new ArrayList<>();
+        ProblemInput problemInput = new ProblemInput();
+        problemInput.setType(ProblemIOType.INTEGER);
+        problemInput.setName("num");
+        problemInputs.add(problemInput);
+
+        Problem problem = new Problem();
+        problem.setTestCases(testCases);
+        problem.setProblemInputs(problemInputs);
+        problem.setOutputType(ProblemIOType.INTEGER);
+
+        return problem;
+    }
 }

--- a/src/test/java/com/rocketden/tester/util/ProblemTestMethods.java
+++ b/src/test/java/com/rocketden/tester/util/ProblemTestMethods.java
@@ -1,6 +1,5 @@
 package com.rocketden.tester.util;
 
-import com.rocketden.tester.model.Language;
 import com.rocketden.tester.model.problem.Problem;
 import com.rocketden.tester.model.problem.ProblemIOType;
 import com.rocketden.tester.model.problem.ProblemInput;
@@ -8,7 +7,6 @@ import com.rocketden.tester.model.problem.ProblemTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class ProblemTestMethods {
 


### PR DESCRIPTION
### List of Changes:

- Create the `RunDto` and `ResultDto` objects to hold the output result and relevant information.
- Create methods to parse the output and store the result in the `RunDto` object.
- Create the `OutputSection` enum to help with parsing.
- Add TODOs to list of tests that cannot be fully implemented.

### Notes:

- The `isOutputCorrect` method just checks the user's output against the test output. Per your notes on #11, our final implementation will be different than this, but I wanted to include some basic placeholder version of this method in this PR.
- Since this PR merged off of `main` (I figured the other branches that are out are not quite finalized, so I thought I'd try to avoid some of those merge conflicts, but I'm open to changing this), the tests are left unimplemented and I added the `DELIMITER` variables in the `DockerService.java` file.
- The `parseCaptureOutput` method is fairly complicated, and part of its inner workings was split off into the helper function `parseTestCaseOutput` in order to break up complexity.
- I use `stringBuilder.setLength(0)` because it is [a fast "clear" method](https://stackoverflow.com/questions/5192512/how-can-i-clear-or-empty-a-stringbuilder).
- I added a field in the `RunDto` object to hold the runtime -- this could be calculated potentially [using `System.currentTimeMillis()`](https://stackoverflow.com/questions/5204051/how-to-calculate-the-running-time-of-my-program).

### Screencast and Images:

There are no changes to the UI and thus no screencasts or images are attached.
